### PR TITLE
getMatlabMainScreen fails on R2022. Reorganise code so it at least do…

### DIFF
--- a/TileFigures.m
+++ b/TileFigures.m
@@ -1,10 +1,11 @@
-function [varargout] = TileFigures(figs, Nrows, Ncols, monitor_id, spacer ,box)
-% TileFigures()
-% TileFigures(figs, Nrows, Ncols, monitor_id, spacer ,box)
-% TileFigures([], [], [], [], [], [])
-% [config] = TileFigures(...)
-% TileFigures(config)
+function varargout = TileFigures(figs, Nrows, Ncols, monitor_id, spacer ,box)
+% Tile figures over the desktop
+%
+% function TileFigures(figs, Nrows, Ncols, monitor_id, spacer ,box)
+%
+% Purpose
 % Tile matlab figures, so that they can be viewed simultaneously, or just more easily managed.
+%
 % INPUT  :
 %       figs : Handles (or indices) array of figures to arrange (default: all)
 %      Nrows : Number of rows (vertical grid) of figures
@@ -24,7 +25,16 @@ function [varargout] = TileFigures(figs, Nrows, Ncols, monitor_id, spacer ,box)
 % [config] = TileFigures(...)  - additionaly, returns the tile configuration for later re-use:
 % TileFigures(config)          - reinstates figures to saved configuration.
 %
-% Notes
+%
+% Examples
+% TileFigures([], [], [], [], [], [])
+% [config] = TileFigures(...)
+% TileFigures(config)
+%
+% Or just run:
+% TileFigures
+%
+%
 % Created: Elimelech Schreiber 25/12/2018
 % Edited:                      21/01/2019
 % lemelech.bi@gmail.com
@@ -34,7 +44,7 @@ function [varargout] = TileFigures(figs, Nrows, Ncols, monitor_id, spacer ,box)
 
 
 %% Controls:
-cascade = 20;      % cascade figures by this number of pixeles (when too many figures), set to zero for total overlap.
+cascade = 20;      % cascade figures by this number of pixels (when too many figures), set to zero for total overlap.
 maxGrid = [3, 6];  % maximum auto grid (doesn't apply to explicit values)
 undock  = true;    % controls whether docked figures will be undocked or left docked.
 task_bar_offset = [0, 50]; % [0, 50] : assumes bottom task bar. 
@@ -48,6 +58,7 @@ extendOnGrid = true; % controls whether figures will be automatically extended t
 if nargin < 6 || isempty(box)
     box = [0, 0, 1, 1];
 end
+
 if nargin < 5 || isempty(spacer)
     spacer  = [1, 1, 1, 1]/400; 
 else
@@ -58,18 +69,22 @@ else
     assert(max(spacer(1:2) + spacer(3:4))<1,'The spacer specified leaves no space for figures.');    
     assert(max(spacer(1:2) + spacer(3:4))<=maxSpacer/100,'Spacer must not exceed %d%.',maxSpacer);    
 end
+
 if nargin < 4 || isempty(monitor_id)
     monitor_id = 0;
     while monitor_id == 0 % don't know why this happens
         monitor_id = getMatlabMainScreen(); %1;
     end
 end
+
 if nargin < 3 || isempty(Ncols)
     Ncols = 0;
 end
+
 if nargin < 2 || isempty(Nrows)
     Nrows = 0;
 end
+
 if nargin < 1 || isempty(figs)
     figHandle = findobj('Type','figure');
     if isempty(figHandle)
@@ -103,6 +118,7 @@ else
 end
 
 n_fig = length(figs);
+
 if n_fig <= 0
     warning('No figures. Go figure...');
     return
@@ -117,6 +133,7 @@ if monitor_id > size(screen_sz,1)
     %matlab and therefor cannot be accounted for.
     return;
 end
+
 screen_sz = screen_sz(monitor_id, :);
 scn_w =  screen_sz(3) - abs(task_bar_offset(1));
 scn_h =  screen_sz(4) - abs(task_bar_offset(2));
@@ -216,27 +233,27 @@ end
 
 %% Tile figures:
 function TileFiguresStruct(TFstruct) 
-for ii = 1:length(TFstruct.figs)
-    if isnan(TFstruct.figs(ii)) || TFstruct.figs(ii)<1 || TFstruct.figs(ii)>length(TFstruct.figHandle) ||...
-            ~isgraphics(TFstruct.figHandle(TFstruct.figs(ii)),'figure')
-        continue;
+    for ii = 1:length(TFstruct.figs)
+        if isnan(TFstruct.figs(ii)) || TFstruct.figs(ii)<1 || TFstruct.figs(ii)>length(TFstruct.figHandle) ||...
+                ~isgraphics(TFstruct.figHandle(TFstruct.figs(ii)),'figure')
+            continue;
+        end
+        if undock
+            set(TFstruct.figHandle(TFstruct.figs(ii)),'WindowStyle','normal');
+        end
+        figure(TFstruct.figHandle(TFstruct.figs(ii)));
+        originalUnits = get(TFstruct.figHandle(TFstruct.figs(ii)),'Units');
+        set(TFstruct.figHandle(TFstruct.figs(ii)),'Units','Pixels','OuterPosition',TFstruct.fig_pos_cell{ii});
+        set(TFstruct.figHandle(TFstruct.figs(ii)),'Units',originalUnits);
+        multiple = find(TFstruct.figs == TFstruct.figs(ii));
+        TFstruct.figs(multiple) = nan;
     end
-    if undock
-        set(TFstruct.figHandle(TFstruct.figs(ii)),'WindowStyle','normal');
-    end
-    figure(TFstruct.figHandle(TFstruct.figs(ii)));
-    originalUnits = get(TFstruct.figHandle(TFstruct.figs(ii)),'Units');
-    set(TFstruct.figHandle(TFstruct.figs(ii)),'Units','Pixels','OuterPosition',TFstruct.fig_pos_cell{ii});
-    set(TFstruct.figHandle(TFstruct.figs(ii)),'Units',originalUnits);
-    multiple = find(TFstruct.figs == TFstruct.figs(ii));
-    TFstruct.figs(multiple) = nan;
-end
-end
+end %TileFiguresStruct
 
-end
+end % Main
 
 
 function figSorted = sortFigureHandles(figs)
-[~, idx] = sort([figs.Number]);
-figSorted = figs(idx);
-end
+    [~, idx] = sort([figs.Number]);
+    figSorted = figs(idx);
+end % sortFigureHandles

--- a/getMatlabMainScreen.m
+++ b/getMatlabMainScreen.m
@@ -1,21 +1,38 @@
 function mon = getMatlabMainScreen(target)
-% mon =  GETMATLABMAINSCREEN(target)
-% returns monitor index.
-% target can be either 'Desktop' - matlab's main window. or 'Editor'-matlab's
-% editor window.
+% Return monitor index
+%
+% function mon = getMatlabMainScreen(target)
+%
+% Purpose
+% Returns monitor index.
+%
+% Inputs
+% target - can be either 'Desktop' (MATLAB's main window) or 'Editor' (MATLAB's
+%          editor window.
+%
+% Outputs
+% mon - the monitory index
 
 if nargin<1
     target = 'Desktop';
 end
+
+
 %% Get monitor list:
 monitors = getMonitors; % uses .Net for windows modified screen positions
 
-%% Get the position of the 'target' MATLAB screen:
+% If there is only one monitor then we return its index and bail out
+nMons = size(monitors,1);
+if nMons == 1
+  mon = 1;
+  return
+end
 
+%% Get the position of the 'target' MATLAB screen:
 switch target
     case 'Desktop'
         %editor position:
-        frame  = com.mathworks.mde.desk.MLDesktop.getInstance.getMainFrame;                
+        frame  = com.mathworks.mde.desk.MLDesktop.getInstance.getMainFrame;
         pt     = frame.getLocationOnScreen;
         center = [frame.getWidth , frame.getHeight]/2;
     case 'Editor'
@@ -27,24 +44,23 @@ end
 
 matlabScreenPos = [pt.x pt.y] + center;%
 
-%% Find the screen in which matlabScreenPos falls:
+
+%% Find the screen in which matlabScreenPos falls in the even that there are multipe screens.
 mon = 0;
-nMons = size(monitors,1);
-if nMons == 1
-  mon = 1;
-else
-    marginLimit = 200;
-    margin =0;
-    while ~mon
-        for ind1 = 1:nMons
-            mon = mon + ind1*(...
-                matlabScreenPos(1) + margin >= monitors(ind1,1) && matlabScreenPos(1) < sum(monitors(ind1,[1 3])) + margin && ...
-                matlabScreenPos(2) + margin >= monitors(ind1,2) && matlabScreenPos(2) < sum(monitors(ind1,[2 4])) + margin );
-        end
-        margin = margin + 10;
-        if margin > marginLimit
-            break;
-        end
+marginLimit = 200;
+margin =0;
+while ~mon
+    for ind1 = 1:nMons
+        mon = mon + ind1*(...
+            matlabScreenPos(1) + margin >= monitors(ind1,1) && matlabScreenPos(1) < sum(monitors(ind1,[1 3])) + margin && ...
+            matlabScreenPos(2) + margin >= monitors(ind1,2) && matlabScreenPos(2) < sum(monitors(ind1,[2 4])) + margin );
     end
-end
+    margin = margin + 10;
+    if margin > marginLimit
+        break
+    end
+end % while
+
+
+end %main
 


### PR DESCRIPTION
`getMatlabMainScreen` fails with

```
Dot indexing is not supported for variables of this type.

Error in getMatlabMainScreen (line 19)
        pt     = frame.getLocationOnScreen;

Error in TileFigures (line 66)
        monitor_id = getMatlabMainScreen(); %1;
 
>>         frame  = com.mathworks.mde.desk.MLDesktop.getInstance.getMainFrame;    
```

This is with R2022a. I don't have more than one monitor so I'm not going to try fixing this issue yet. Instead I reorganised the code so it bypasses the problematic section if only one monitor is present. That bit does not need to run unless there are multiple screens. 